### PR TITLE
Improve AssertionFailed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,18 +141,23 @@ use Zenstruck\Assert\AssertionFailed;
 // The `throw()` named constructor creates the exception and immediately throws it
 AssertionFailed::throw('Some message');
 
-// second parameter can be used as sprintf values for the message
-// message = 'Expected "value 1" but got "value 2"'
-AssertionFailed::throw('Expected "%s" but got "%s"', ['value 1', 'value 2']);
+// a second "context" parameter can be used as sprintf values for the message
+AssertionFailed::throw('Expected "%s" but got "%s"', ['value 1', 'value 2']); // Expected "value 1" but got "value 2"
 
-// when an associated array passed as the second parameter, the message is constructed
+// when an associated array passed as the context parameter, the message is constructed
 // with a simple template system
-// message = 'Expected "value 1" but got "value 2"'
-AssertionFailed::throw('Expected "{expected}" but got "{actual}"', [
+AssertionFailed::throw('Expected "{expected}" but got "{actual}"', [ // Expected "value 1" but got "value 2"
     'expected' => 'value 1',
     'actual' => 'value 2',
 ]);
 ```
+
+**NOTES:**
+1. When the message is constructed with context, non-scalar values are run through
+`get_debug_type()` and strings longer than _40_ characters are trimmed. The full context
+is available via `AssertionFailed::context()`.
+2. When using with PHPUnit, the full context is exported with the failure message if in
+_verbose-mode_ (`--verbose|-v`).
 
 ## Assertion Objects
 

--- a/src/Assert/Handler/PHPUnitHandler.php
+++ b/src/Assert/Handler/PHPUnitHandler.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Assert\Handler;
 
 use PHPUnit\Framework\Assert as PHPUnit;
+use SebastianBergmann\Exporter\Exporter;
 use Zenstruck\Assert\AssertionFailed;
 use Zenstruck\Assert\Handler;
 
@@ -21,11 +22,41 @@ final class PHPUnitHandler implements Handler
 
     public function onFailure(AssertionFailed $exception): void
     {
-        PHPUnit::fail($exception->getMessage());
+        PHPUnit::fail(self::failureMessage($exception));
+    }
+
+    public static function isVerbose(): bool
+    {
+        return \in_array('--verbose', $_SERVER['argv'], true) || \in_array('-v', $_SERVER['argv'], true);
     }
 
     public static function isSupported(): bool
     {
         return \class_exists(PHPUnit::class);
+    }
+
+    private static function failureMessage(AssertionFailed $exception): string
+    {
+        $message = $exception->getMessage();
+
+        if (!($context = $exception->context()) || !self::isVerbose()) {
+            return $message;
+        }
+
+        $message .= "\n\nFailure Context:\n\n";
+        $exporter = new Exporter();
+
+        foreach ($context as $name => $value) {
+            $exported = $exporter->export($value);
+
+            if (\mb_strlen($exported) > 5000) {
+                // prevent ridiculously long objects
+                $exported = $exporter->shortenedExport($value);
+            }
+
+            $message .= \sprintf("[%s]\n%s\n\n", $name, $exported);
+        }
+
+        return $message;
     }
 }

--- a/tests/AssertionFailedTest.php
+++ b/tests/AssertionFailedTest.php
@@ -20,19 +20,22 @@ final class AssertionFailedTest extends TestCase
         $this->assertSame('message %s', $exception->getMessage());
         $this->assertSame([], $exception->context());
 
-        $exception = new AssertionFailed('message %s %s %s %s %s', [1, 'string', 4.3, $object = new \stdClass(), ['foo']]);
-
-        $this->assertSame('message 1 string 4.3 stdClass (array)', $exception->getMessage());
-        $this->assertSame(
-            [
+        $exception = new AssertionFailed(
+            'message %s %s %s %s %s %s %s %s',
+            $expected = [
                 1,
                 'string',
                 4.3,
-                $object,
-                ['foo'],
-            ],
-            $exception->context()
+                new \stdClass(),
+                null,
+                ['an', 'array'],
+                'The quick brown fox jumps over the lazy dog',
+                "string\nwith\n\rline\nbreak",
+            ]
         );
+
+        $this->assertSame('message 1 string 4.3 stdClass (null) (array) The quick brown fox jumps o...e lazy dog string with line break', $exception->getMessage());
+        $this->assertSame($expected, $exception->context());
     }
 
     /**
@@ -41,14 +44,16 @@ final class AssertionFailedTest extends TestCase
     public function message_is_created_with_context_as_assoc_array(): void
     {
         $object = new \stdClass();
-        $messageTemplate = 'message {int} {string} {float} {object} {array}';
-        $expectedMessage = 'message 1 value 4.3 stdClass (array)';
+        $messageTemplate = 'message {int} {string1} {float} {object} {array} {string2} {string3}';
+        $expectedMessage = 'message 1 value 4.3 stdClass (array) The quick brown fox jumps o...e lazy dog string with line break';
         $expectedContext = [
             'int' => 1,
-            'string' => 'value',
+            'string1' => 'value',
             'float' => 4.3,
             'object' => $object,
             'array' => ['foo'],
+            'string2' => 'The quick brown fox jumps over the lazy dog',
+            'string3' => "string\nwith\n\rline\nbreak",
         ];
 
         $exception = new AssertionFailed($messageTemplate, $expectedContext);
@@ -58,10 +63,12 @@ final class AssertionFailedTest extends TestCase
 
         $exception = new AssertionFailed($messageTemplate, [
             '{int}' => 1,
-            '{string}' => 'value',
+            '{string1}' => 'value',
             'float' => 4.3,
             '{object}' => $object,
             '{array}' => ['foo'],
+            '{string2}' => 'The quick brown fox jumps over the lazy dog',
+            '{string3}' => "string\nwith\n\rline\nbreak",
         ]);
 
         $this->assertSame($expectedMessage, $exception->getMessage());

--- a/tests/Handler/PHPUnitHandlerTest.php
+++ b/tests/Handler/PHPUnitHandlerTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Assert;
+use Zenstruck\Assert\Handler\PHPUnitHandler;
+use Zenstruck\Assert\Tests\Fixture\NegatableAssertion;
 use Zenstruck\Assert\Tests\ResetHandler;
 
 /**
@@ -46,6 +48,63 @@ final class PHPUnitHandlerTest extends TestCase
         } catch (AssertionFailedError $e) {
             $this->assertSame(1, PHPUnit::getCount() - $initialPHPUnitAssertionCount, 'The failure should trigger an assertion count');
             $this->assertSame('this fails', $e->getMessage());
+
+            return;
+        }
+
+        PHPUnit::fail('No PHPUnit failure.');
+    }
+
+    /**
+     * @test
+     */
+    public function non_verbose_run_does_not_export_context(): void
+    {
+        if (PHPUnitHandler::isVerbose()) {
+            $this->markTestSkipped('Skip if verbose.');
+        }
+
+        try {
+            Assert::true(false, 'this fails {string} {array} {object}', [
+                'string' => 'The quick brown fox jumps over the lazy dog',
+                'array' => ['an' => 'array'],
+                'object' => $this,
+            ]);
+        } catch (AssertionFailedError $e) {
+            $this->assertSame(\sprintf('this fails The quick brown fox jumps o...e lazy dog (array) %s', __CLASS__), $e->getMessage());
+
+            return;
+        }
+
+        PHPUnit::fail('No PHPUnit failure.');
+    }
+
+    /**
+     * @test
+     */
+    public function verbose_run_exports_context(): void
+    {
+        if (!PHPUnitHandler::isVerbose()) {
+            $this->markTestSkipped('Skip if not verbose.');
+        }
+
+        try {
+            Assert::true(false, 'this fails {string} {array} {object1} {object2}', [
+                'string' => 'The quick brown fox jumps over the lazy dog',
+                'array' => ['an' => 'array'],
+                'object1' => $this,
+                'object2' => new NegatableAssertion(true),
+            ]);
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString(
+                \sprintf("this fails The quick brown fox jumps o...e lazy dog (array) %s %s\n\nFailure Context:", __CLASS__, NegatableAssertion::class),
+                $e->getMessage()
+            );
+            $this->assertStringContainsString("[string]\n'The quick brown fox jumps over the lazy dog'", $e->getMessage());
+            $this->assertStringContainsString("[array]\nArray &0 (\n    'an' => 'array'\n)", $e->getMessage());
+            $this->assertStringContainsString(\sprintf("[object1]\n%s Object (...)", __CLASS__), $e->getMessage());
+            $this->assertStringContainsString(\sprintf("object2]\n%s Object &", NegatableAssertion::class), $e->getMessage());
+            $this->assertStringContainsString("    'fail' => true\n)", $e->getMessage());
 
             return;
         }


### PR DESCRIPTION
Closes #1 

When running `phpunit -v|--verbose`, the context is output below the failure message:

```
There was 1 failure:

1) Zenstruck\Assert\Tests\Handler\PHPUnitHandlerTest::verbose_run_exports_context
this fails The quick brown fox jumps o...e lazy dog (array) Zenstruck\Assert\Tests\Handler\PHPUnitHandlerTest Zenstruck\Assert\Tests\Fixture\NegatableAssertion

Failure Context:

[string]
'The quick brown fox jumps over the lazy dog'

[array]
Array &0 (
    'an' => 'array'
)

[object1]
Zenstruck\Assert\Tests\Handler\PHPUnitHandlerTest Object (...)

[object2]
Zenstruck\Assert\Tests\Fixture\NegatableAssertion Object &0000000045c6ec51000000003b32d2a7 (
    'fail' => true
)
```