### PR TITLE
Add `TypeAssertion` and type expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Assert::that(6)->isNot(6); // fail
 Assert::that('foo')->isNot('bar'); // pass
 Assert::that(6)->isNot('6'); // pass
 
+// instanceof
+Assert::that($object)->isInstanceOf(Some::class);
+
+Assert::that($object)->isNotInstanceOf(Some::class);
+
 // greater than
 Assert::that(2)->isGreaterThan(1); // pass
 Assert::that(2)->isGreaterThan(1); // fail
@@ -187,6 +192,46 @@ Assert::that(3)->isLessThan(3); // fail
 Assert::that(3)->isLessThanOrEqualTo(4); // pass
 Assert::that(3)->isLessThanOrEqualTo(2); // fail
 Assert::that(3)->isLessThanOrEqualTo(3); // pass
+```
+
+### Type Expectations
+
+```php
+use Zenstruck\Assert;
+use Zenstruck\Assert\Type;
+
+Assert::that($something)->is(Type::bool());
+Assert::that($something)->is(Type::int());
+Assert::that($something)->is(Type::float());
+Assert::that($something)->is(Type::numeric());
+Assert::that($something)->is(Type::string());
+Assert::that($something)->is(Type::callable());
+Assert::that($something)->is(Type::iterable());
+Assert::that($something)->is(Type::countable());
+Assert::that($something)->is(Type::object());
+Assert::that($something)->is(Type::resource());
+Assert::that($something)->is(Type::array());
+Assert::that($something)->is(Type::arrayList()); // [1, 2, 3] passes but ['foo' => 'bar'] does not
+Assert::that($something)->is(Type::arrayAssoc()); // ['foo' => 'bar'] passes but [1, 2, 3] does not
+Assert::that($something)->is(Type::arrayEmpty()); // [] passes but [1, 2, 3] does not
+Assert::that($something)->is(Type::json()); // valid json string
+
+// "Not's"
+Assert::that($something)->isNot(Type::bool());
+Assert::that($something)->isNot(Type::int());
+Assert::that($something)->isNot(Type::float());
+Assert::that($something)->isNot(Type::numeric());
+Assert::that($something)->isNot(Type::string());
+Assert::that($something)->isNot(Type::callable());
+Assert::that($something)->isNot(Type::iterable());
+Assert::that($something)->isNot(Type::countable());
+Assert::that($something)->isNot(Type::object());
+Assert::that($something)->isNot(Type::resource());
+Assert::that($something)->isNot(Type::array());
+Assert::that($something)->isNot(Type::arrayList());
+Assert::that($something)->isNot(Type::arrayAssoc());
+Assert::that($something)->isNot(Type::arrayEmpty());
+Assert::that($something)->isNot(Type::json());
 ```
 
 ### Throws Expectation

--- a/src/Assert/Assertion/TypeAssertion.php
+++ b/src/Assert/Assertion/TypeAssertion.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Zenstruck\Assert\Assertion;
+
+use Zenstruck\Assert\Type;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class TypeAssertion extends EvaluableAssertion
+{
+    /** @var mixed */
+    private $value;
+
+    /** @var Type */
+    private $expected;
+
+    /**
+     * @param mixed       $value
+     * @param string|null $message Available context: {value}, {expected}, {actual}
+     */
+    public function __construct($value, Type $expected, ?string $message = null, array $context = [])
+    {
+        $this->value = $value;
+        $this->expected = $expected;
+
+        parent::__construct($message, $context);
+    }
+
+    protected function evaluate(): bool
+    {
+        return ($this->expected)($this->value);
+    }
+
+    protected function defaultFailureMessage(): string
+    {
+        return 'Expected "{value}" to be of type {expected} but is {actual}.';
+    }
+
+    protected function defaultNotFailureMessage(): string
+    {
+        return 'Expected "{value}" to NOT be of type {expected}.';
+    }
+
+    protected function defaultContext(): array
+    {
+        return [
+            'value' => $this->value,
+            'expected' => (string) $this->expected,
+            'actual' => \get_debug_type($this->value),
+        ];
+    }
+}

--- a/src/Assert/Expectation.php
+++ b/src/Assert/Expectation.php
@@ -8,6 +8,7 @@ use Zenstruck\Assert\Assertion\ContainsAssertion;
 use Zenstruck\Assert\Assertion\CountAssertion;
 use Zenstruck\Assert\Assertion\EmptyAssertion;
 use Zenstruck\Assert\Assertion\ThrowsAssertion;
+use Zenstruck\Assert\Assertion\TypeAssertion;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -200,11 +201,19 @@ final class Expectation
     /**
      * Asserts the expectation value and $expected are "the same" using "===".
      *
-     * @param mixed       $expected
+     * If a {@see Type} object is passed as expected, asserts the type matches.
+     *
+     * @param mixed|Type  $expected
      * @param string|null $message  Available context: {expected}, {actual}
      */
     public function is($expected, ?string $message = null, array $context = []): self
     {
+        if ($expected instanceof Type) {
+            Assert::run(new TypeAssertion($this->value, $expected, $message, $context));
+
+            return $this;
+        }
+
         Assert::run(ComparisonAssertion::same($this->value, $expected, $message, $context));
 
         return $this;
@@ -213,11 +222,19 @@ final class Expectation
     /**
      * Asserts the expectation value and $expected are NOT "the same" using "!==".
      *
-     * @param mixed       $expected
+     * If a {@see Type} object is passed as expected, asserts the type DOES NOT matche.
+     *
+     * @param mixed|Type  $expected
      * @param string|null $message  Available context: {expected}, {actual}
      */
     public function isNot($expected, ?string $message = null, array $context = []): self
     {
+        if ($expected instanceof Type) {
+            Assert::not(new TypeAssertion($this->value, $expected, $message, $context));
+
+            return $this;
+        }
+
         Assert::not(ComparisonAssertion::same($this->value, $expected, $message, $context));
 
         return $this;

--- a/src/Assert/Type.php
+++ b/src/Assert/Type.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Zenstruck\Assert;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Type
+{
+    private const BOOL = 'bool';
+    private const STRING = 'string';
+    private const INT = 'int';
+    private const FLOAT = 'float';
+    private const NUMERIC = 'numeric';
+    private const CALLABLE = 'callable';
+    private const RESOURCE = 'resource';
+    private const ITERABLE = 'iterable';
+    private const COUNTABLE = 'countable';
+    private const OBJECT = 'object';
+    private const ARRAY = 'array';
+    private const ARRAY_LIST = 'array:list';
+    private const ARRAY_ASSOC = 'array:assoc';
+    private const ARRAY_EMPTY = 'array:empty';
+    private const STRING_JSON = 'string:json';
+
+    /** @var string */
+    private $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @internal
+     *
+     * @param mixed $value
+     */
+    public function __invoke($value): bool
+    {
+        switch ($this->value) {
+            case self::BOOL:
+                return \is_bool($value);
+
+            case self::STRING:
+                return \is_string($value);
+
+            case self::INT:
+                return \is_int($value);
+
+            case self::FLOAT:
+                return \is_float($value);
+
+            case self::NUMERIC:
+                return \is_numeric($value);
+
+            case self::CALLABLE:
+                return \is_callable($value);
+
+            case self::RESOURCE:
+                return \is_resource($value);
+
+            case self::OBJECT:
+                return \is_object($value);
+
+            case self::ITERABLE:
+                return \is_iterable($value);
+
+            case self::COUNTABLE:
+                return \is_countable($value);
+
+            case self::ARRAY:
+                return \is_array($value);
+
+            case self::ARRAY_LIST:
+                return \is_array($value) && $value && array_is_list($value);
+
+            case self::ARRAY_ASSOC:
+                return \is_array($value) && $value && !array_is_list($value);
+
+            case self::ARRAY_EMPTY:
+                return \is_array($value) && !$value;
+
+            case self::STRING_JSON:
+                return self::isJson($value);
+        }
+
+        return \is_object($value) && $this->value === \get_class($value);
+    }
+
+    /**
+     * @internal
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public static function bool(): self
+    {
+        return new self(self::BOOL);
+    }
+
+    public static function string(): self
+    {
+        return new self(self::STRING);
+    }
+
+    public static function int(): self
+    {
+        return new self(self::INT);
+    }
+
+    public static function float(): self
+    {
+        return new self(self::FLOAT);
+    }
+
+    public static function numeric(): self
+    {
+        return new self(self::NUMERIC);
+    }
+
+    public static function callable(): self
+    {
+        return new self(self::CALLABLE);
+    }
+
+    public static function resource(): self
+    {
+        return new self(self::RESOURCE);
+    }
+
+    public static function iterable(): self
+    {
+        return new self(self::ITERABLE);
+    }
+
+    public static function countable(): self
+    {
+        return new self(self::COUNTABLE);
+    }
+
+    public static function array(): self
+    {
+        return new self(self::ARRAY);
+    }
+
+    public static function arrayList(): self
+    {
+        return new self(self::ARRAY_LIST);
+    }
+
+    public static function arrayAssoc(): self
+    {
+        return new self(self::ARRAY_ASSOC);
+    }
+
+    public static function arrayEmpty(): self
+    {
+        return new self(self::ARRAY_EMPTY);
+    }
+
+    public static function json(): self
+    {
+        return new self(self::STRING_JSON);
+    }
+
+    public static function object(): self
+    {
+        return new self(self::OBJECT);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function isJson($value): bool
+    {
+        if (!\is_string($value)) {
+            return false;
+        }
+
+        // TODO: use \JSON_THROW_ON_ERROR once min PHP >= 7.3
+        \json_decode($value);
+
+        return \JSON_ERROR_NONE === \json_last_error();
+    }
+}

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Zenstruck\Assert;
 use Zenstruck\Assert\Tests\Fixture\CountableObject;
 use Zenstruck\Assert\Tests\Fixture\IterableObject;
+use Zenstruck\Assert\Type;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -553,6 +554,120 @@ final class ExpectationTest extends TestCase
                 ->contains('bar')
             ;
         });
+    }
+
+    /**
+     * @test
+     * @dataProvider isTypePassProvider
+     *
+     * @param mixed $value
+     */
+    public function is_type_success($value, Type $type): void
+    {
+        $this->assertSuccess(1, function() use ($value, $type) {
+            Assert::that($value)->is($type);
+        });
+    }
+
+    /**
+     * @test
+     * @dataProvider isTypeFailProvider
+     *
+     * @param mixed $value
+     */
+    public function is_type_failure($value, Type $type, ?string $normalizedValue = null): void
+    {
+        $this->assertFails(
+            \sprintf('Expected "%s" to be of type %s but is %s.', $normalizedValue ?? $value, $type, \get_debug_type($value)),
+            function() use ($value, $type) {
+                Assert::that($value)->is($type);
+            }
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider isTypeFailProvider
+     *
+     * @param mixed $value
+     */
+    public function is_not_type_success($value, Type $type): void
+    {
+        $this->assertSuccess(1, function() use ($value, $type) {
+            Assert::that($value)->isNot($type);
+        });
+    }
+
+    /**
+     * @test
+     * @dataProvider isTypePassProvider
+     *
+     * @param mixed $value
+     */
+    public function is_not_type_failure($value, Type $type, ?string $normalizedValue = null): void
+    {
+        $this->assertFails(
+            \sprintf('Expected "%s" to NOT be of type %s.', $normalizedValue ?? $value, $type),
+            function() use ($value, $type) {
+                Assert::that($value)->isNot($type);
+            }
+        );
+    }
+
+    public static function isTypePassProvider(): iterable
+    {
+        yield [false, Type::bool(), '(false)'];
+        yield [5, Type::int()];
+        yield [5.0, Type::float()];
+        yield ['5', Type::string()];
+        yield [5, Type::numeric()];
+        yield [5.0, Type::numeric()];
+        yield ['5', Type::numeric()];
+        yield [function() {}, Type::callable(), 'Closure'];
+        yield [\fopen(__DIR__, 'r'), Type::resource(), '(resource (stream))'];
+        yield [[], Type::iterable(), '(array:empty)'];
+        yield [[], Type::countable(), '(array:empty)'];
+        yield [new \ArrayIterator([]), Type::countable(), 'ArrayIterator'];
+        yield [new \ArrayIterator([]), Type::iterable(), 'ArrayIterator'];
+        yield [new \ArrayIterator([]), Type::object(), 'ArrayIterator'];
+        yield [[], Type::array(), '(array:empty)'];
+        yield [['foo'], Type::array(), '(array:list)'];
+        yield [['foo' => 'bar'], Type::array(), '(array:assoc)'];
+        yield [['foo'], Type::arrayList(), '(array:list)'];
+        yield [['foo' => 'bar'], Type::arrayAssoc(), '(array:assoc)'];
+        yield [[], Type::arrayEmpty(), '(array:empty)'];
+        yield ['{"foo": 5}', Type::json()];
+        yield ['[]', Type::json()];
+        yield ['null', Type::json()];
+        yield ['false', Type::json()];
+        yield ['"foo"', Type::json()];
+    }
+
+    public static function isTypeFailProvider(): iterable
+    {
+        yield ['5', Type::int()];
+        yield [5, Type::string()];
+        yield [5, Type::bool()];
+        yield [false, Type::numeric(), '(false)'];
+        yield [6, Type::float()];
+        yield [6, Type::callable()];
+        yield [5, Type::resource()];
+        yield [1, Type::iterable()];
+        yield [1, Type::countable()];
+        yield [new \IteratorIterator(new \ArrayIterator()), Type::countable(), 'IteratorIterator'];
+        yield [1, Type::object()];
+        yield [1, Type::array()];
+        yield [1, Type::arrayList()];
+        yield [1, Type::arrayAssoc()];
+        yield [['foo' => 'bar'], Type::arrayList(), '(array:assoc)'];
+        yield [['foo'], Type::arrayAssoc(), '(array:list)'];
+        yield [[], Type::arrayList(), '(array:empty)'];
+        yield [[], Type::arrayAssoc(), '(array:empty)'];
+        yield [['foo'], Type::arrayEmpty(), '(array:list)'];
+        yield [1, Type::arrayEmpty()];
+        yield [[], Type::json(), '(array:empty)'];
+        yield [new \stdClass(), Type::json(), 'stdClass'];
+        yield ['foo', Type::json()];
     }
 
     private function assertSuccess(int $expectedCount, callable $what): self

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zenstruck\Assert\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Assert\Type;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class TypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function named_constructors(): void
+    {
+        $this->assertSame('bool', (string) Type::bool());
+        $this->assertSame('string', (string) Type::string());
+        $this->assertSame('int', (string) Type::int());
+        $this->assertSame('float', (string) Type::float());
+        $this->assertSame('numeric', (string) Type::numeric());
+        $this->assertSame('array', (string) Type::array());
+        $this->assertSame('array:assoc', (string) Type::arrayAssoc());
+        $this->assertSame('array:list', (string) Type::arrayList());
+        $this->assertSame('array:empty', (string) Type::arrayEmpty());
+        $this->assertSame('callable', (string) Type::callable());
+        $this->assertSame('resource', (string) Type::resource());
+        $this->assertSame('object', (string) Type::object());
+        $this->assertSame('iterable', (string) Type::iterable());
+        $this->assertSame('countable', (string) Type::countable());
+        $this->assertSame('string:json', (string) Type::json());
+    }
+}


### PR DESCRIPTION
```php
use Zenstruck\Assert;
use Zenstruck\Assert\Type;

Assert::that($something)->is(Type::bool());
Assert::that($something)->is(Type::int());
Assert::that($something)->is(Type::float());
Assert::that($something)->is(Type::numeric());
Assert::that($something)->is(Type::string());
Assert::that($something)->is(Type::callable());
Assert::that($something)->is(Type::iterable());
Assert::that($something)->is(Type::countable());
Assert::that($something)->is(Type::object());
Assert::that($something)->is(Type::resource());
Assert::that($something)->is(Type::array());
Assert::that($something)->is(Type::arrayList()); // [1, 2, 3] passes but ['foo' => 'bar'] does not
Assert::that($something)->is(Type::arrayAssoc()); // ['foo' => 'bar'] passes but [1, 2, 3] does not
Assert::that($something)->is(Type::arrayEmpty()); // [] passes but [1, 2, 3] does not
Assert::that($something)->is(Type::json()); // valid json string

// "Not's"
Assert::that($something)->isNot(Type::bool());
Assert::that($something)->isNot(Type::int());
Assert::that($something)->isNot(Type::float());
Assert::that($something)->isNot(Type::numeric());
Assert::that($something)->isNot(Type::string());
Assert::that($something)->isNot(Type::callable());
Assert::that($something)->isNot(Type::iterable());
Assert::that($something)->isNot(Type::countable());
Assert::that($something)->isNot(Type::object());
Assert::that($something)->isNot(Type::resource());
Assert::that($something)->isNot(Type::array());
Assert::that($something)->isNot(Type::arrayList());
Assert::that($something)->isNot(Type::arrayAssoc());
Assert::that($something)->isNot(Type::arrayEmpty());
Assert::that($something)->isNot(Type::json());
```