### PR TITLE
minor: add output to ArraySubset failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=8.0",
-        "symfony/polyfill-php81": "^1.23"
+        "symfony/polyfill-php81": "^1.23",
+        "symfony/var-exporter": "^5.4|^6.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",

--- a/tests/ExpectationTest.php
+++ b/tests/ExpectationTest.php
@@ -772,7 +772,7 @@ final class ExpectationTest extends TestCase
         $what();
 
         $this->assertSame(1, $this->handler->failureCount(), 'Did not fail.');
-        $this->assertSame($expectedMessage, $this->handler->lastFailureMessage());
+        $this->assertStringContainsString($expectedMessage, $this->handler->lastFailureMessage());
 
         return $this;
     }


### PR DESCRIPTION
`ArraySubsetAssertionTest` is really nice and powerful used along `zenstruck/browser`'s json capabilities but IMO it's lacking some output when the assertion failed: it only displays `Expected haystack to have needle as subset.` and the developer needs to add a `->dd()` in the code to know the difference between expected and actual data, which is not a really good DX.

At first, I wanted to use https://github.com/sebastianbergmann/comparator in order to only display which part of the subset fails, and in order to have coherent output with what phpunit does, but I really didn't manage to get anything neat, I've spent too much time on that: the whole "array is list" stuff is quite impossible to deal with and have a nice diff :disappointed:

So I ended up to display full `$needle` and `$haystack` which is not optimal IMO, but still better than nothing.